### PR TITLE
[POC] Using a discovery trait to enable PR support

### DIFF
--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClient.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClient.java
@@ -3,6 +3,7 @@ package com.atlassian.bitbucket.jenkins.internal.client;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.*;
 import com.atlassian.bitbucket.jenkins.internal.scm.filesystem.BitbucketSCMFile;
 import jenkins.scm.api.SCMFile;
+import jenkins.scm.api.SCMFile.Type;
 
 import java.util.List;
 
@@ -12,6 +13,21 @@ import java.util.List;
  * @since 3.0.0
  */
 public interface BitbucketFilePathClient {
+
+    /**
+     * Retrieves the list of all files and directories that can be found.
+     *
+     * @param path the path of the file or directory to retrieve
+     * @param ref The commit ID or ref to retrieve the file for
+     *
+     * @return the {@link Type type} for the specified file
+     * @throws AuthorizationException     if the credentials did not allow access to the given url
+     * @throws ConnectionFailureException if the server did not respond
+     * @throws BadRequestException        if the request was malformed and thus rejected by the server
+     * @throws ServerErrorException       if the server failed to process the request
+     * @throws BitbucketClientException   for all errors not already captured
+     */
+    Type getFileType(String path, String ref);
 
     /**
      * Retrieves the list of all files and directories that can be found.

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClientImpl.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/client/BitbucketFilePathClientImpl.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.client;
 
+import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
 import com.atlassian.bitbucket.jenkins.internal.client.paging.BitbucketPageStreamUtil;
 import com.atlassian.bitbucket.jenkins.internal.client.paging.NextPageFetcher;
 import com.atlassian.bitbucket.jenkins.internal.model.*;
@@ -28,6 +29,24 @@ public class BitbucketFilePathClientImpl implements BitbucketFilePathClient {
         this.bitbucketRequestExecutor = bitbucketRequestExecutor;
         this.projectKey = projectKey;
         this.repositorySlug = repositorySlug;
+    }
+
+    @Override
+    public Type getFileType(String path, String ref) {
+        HttpUrl url = getUrlBuilder(path, ref).addQueryParameter("type", "true").build();
+        try {
+            BitbucketDirectoryChild file = bitbucketRequestExecutor
+                    .makeGetRequest(url, BitbucketDirectoryChild.class)
+                    .getBody();
+
+            if ("FILE".equals(file.getType())) {
+                return REGULAR_FILE;
+            }
+
+            return DIRECTORY;
+        } catch (NotFoundException e) {
+            return NONEXISTENT;
+        }
     }
 
     @Override
@@ -60,16 +79,23 @@ public class BitbucketFilePathClientImpl implements BitbucketFilePathClient {
     }
 
     private HttpUrl getUrl(BitbucketSCMFile scmFile) {
+        return getUrlBuilder(scmFile.getFilePath(), scmFile.getRef().orElse(null)).build();
+    }
+
+    private HttpUrl.Builder getUrlBuilder(String filePath, String ref) {
         HttpUrl.Builder urlBuilder = bitbucketRequestExecutor.getCoreRestPath().newBuilder()
                 .addPathSegment("projects")
                 .addPathSegment(projectKey)
                 .addPathSegment("repos")
                 .addPathSegment(repositorySlug)
                 .addPathSegment("browse")
-                .addPathSegments(scmFile.getFilePath());
-        scmFile.getRef().map(ref -> urlBuilder.addQueryParameter("at", ref));
+                .addPathSegments(filePath);
 
-        return urlBuilder.build();
+        if (ref != null) {
+            urlBuilder.addQueryParameter("at", ref);
+        }
+
+        return urlBuilder;
     }
 
     static class DirectoryNextPageFetcher implements NextPageFetcher<BitbucketDirectoryChild> {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketDiscoverableHeadType.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketDiscoverableHeadType.java
@@ -1,0 +1,6 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+public enum BitbucketDiscoverableHeadType {
+
+    PULL_REQUEST
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
@@ -4,12 +4,14 @@ import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestState;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+import org.apache.commons.lang3.StringUtils;
 
 import static java.util.Objects.requireNonNull;
 
 public class BitbucketPullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
 
-    public static final String PR_ID_PREFIX = "pr#";
+    public static final int PR_NAME_BRANCH_MAX_LENGTH = 20;
+    public static final String PR_NAME_TEMPLATE = "pr%s--%s--%s";
 
     private final String branchName;
     private final String latestCommit;
@@ -19,7 +21,7 @@ public class BitbucketPullRequestSCMHead extends SCMHead implements ChangeReques
 
     public BitbucketPullRequestSCMHead(String branchName, String latestCommit, String pullRequestId,
                                        BitbucketPullRequestState pullRequestState, SCMHead target) {
-        super(PR_ID_PREFIX + pullRequestId);
+        super(formatPRName(pullRequestId, branchName, target.getName()));
         this.branchName = requireNonNull(branchName, "branchName");
         this.latestCommit = requireNonNull(latestCommit, "latestCommit");
         this.pullRequestId = requireNonNull(pullRequestId, "pullRequestId");
@@ -53,5 +55,12 @@ public class BitbucketPullRequestSCMHead extends SCMHead implements ChangeReques
 
     public boolean isPullRequestOpen() {
         return pullRequestState == BitbucketPullRequestState.OPEN;
+    }
+
+    private static String formatPRName(String pullRequestId, String branchName, String targetBranchName) {
+        return String.format(PR_NAME_TEMPLATE,
+                pullRequestId,
+                StringUtils.truncate(branchName, PR_NAME_BRANCH_MAX_LENGTH),
+                StringUtils.truncate(targetBranchName, PR_NAME_BRANCH_MAX_LENGTH));
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 public class BitbucketPullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
 
-    private static final String PR_ID_PREFIX = "pr#";
+    public static final String PR_ID_PREFIX = "pr#";
 
     private final String branchName;
     private final String latestCommit;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMHead.java
@@ -1,0 +1,57 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestState;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead2;
+
+import static java.util.Objects.requireNonNull;
+
+public class BitbucketPullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2 {
+
+    private static final String PR_ID_PREFIX = "pr#";
+
+    private final String branchName;
+    private final String latestCommit;
+    private final String pullRequestId;
+    private final BitbucketPullRequestState pullRequestState;
+    private final SCMHead target;
+
+    public BitbucketPullRequestSCMHead(String branchName, String latestCommit, String pullRequestId,
+                                       BitbucketPullRequestState pullRequestState, SCMHead target) {
+        super(PR_ID_PREFIX + pullRequestId);
+        this.branchName = requireNonNull(branchName, "branchName");
+        this.latestCommit = requireNonNull(latestCommit, "latestCommit");
+        this.pullRequestId = requireNonNull(pullRequestId, "pullRequestId");
+        this.pullRequestState = requireNonNull(pullRequestState, "pullRequestState");
+        this.target = requireNonNull(target, "target");
+    }
+
+    @Override
+    public ChangeRequestCheckoutStrategy getCheckoutStrategy() {
+        return ChangeRequestCheckoutStrategy.MERGE;
+    }
+
+    @Override
+    public String getId() {
+        return pullRequestId;
+    }
+
+    public String getLatestCommit() {
+        return latestCommit;
+    }
+
+    @Override
+    public String getOriginName() {
+        return branchName;
+    }
+
+    @Override
+    public SCMHead getTarget() {
+        return target;
+    }
+
+    public boolean isPullRequestOpen() {
+        return pullRequestState == BitbucketPullRequestState.OPEN;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMRevision.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMRevision.java
@@ -1,0 +1,68 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequest;
+import com.atlassian.bitbucket.jenkins.internal.model.BitbucketPullRequestRef;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class BitbucketPullRequestSCMRevision extends ChangeRequestSCMRevision<BitbucketPullRequestSCMHead> {
+
+    private final String latestCommit;
+
+    public BitbucketPullRequestSCMRevision(BitbucketPullRequestSCMHead head, SCMRevision target) {
+        super(head, target);
+        this.latestCommit = requireNonNull(head, "head").getLatestCommit();
+    }
+
+    public static BitbucketPullRequestSCMRevision fromPullRequest(BitbucketPullRequest pullRequest) {
+        requireNonNull(pullRequest, "pullRequest");
+
+        BitbucketPullRequestRef fromRef = pullRequest.getFromRef();
+        BitbucketPullRequestRef toRef = pullRequest.getToRef();
+
+        BitbucketSCMHead targetHead = new BitbucketSCMHead(toRef.getDisplayId(), toRef.getLatestCommit());
+        SCMRevision targetRevision = new BitbucketSCMRevision(targetHead);
+        BitbucketPullRequestSCMHead sourceHead =
+                new BitbucketPullRequestSCMHead(fromRef.getDisplayId(),
+                        fromRef.getLatestCommit(),
+                        String.valueOf(pullRequest.getId()),
+                        pullRequest.getState(),
+                        targetHead);
+        return new BitbucketPullRequestSCMRevision(sourceHead, targetRevision);
+    }
+
+    public static BitbucketPullRequestSCMRevision fromPullRequestHead(BitbucketPullRequestSCMHead prHead) {
+        requireNonNull(prHead, "prHead");
+        BitbucketSCMHead targetHead = (BitbucketSCMHead) prHead.getTarget();
+        SCMRevision targetRevision = new BitbucketSCMRevision(targetHead);
+        return new BitbucketPullRequestSCMRevision(prHead, targetRevision);
+    }
+
+    @Override
+    public boolean equivalent(ChangeRequestSCMRevision<?> revision) {
+        if (revision instanceof BitbucketPullRequestSCMRevision) {
+            BitbucketPullRequestSCMRevision that = (BitbucketPullRequestSCMRevision) revision;
+            return getHead().equals(that.getHead()) && latestCommit.equals(that.latestCommit);
+        }
+
+        return false;
+    }
+
+    public boolean isPullRequestOpen() {
+        return ((BitbucketPullRequestSCMHead) getHead()).isPullRequestOpen();
+    }
+
+    @Override
+    protected int _hashCode() {
+        return Objects.hash(getHead(), latestCommit);
+    }
+
+    @Override
+    public String toString() {
+        return "merge: " + latestCommit + " + " + getTarget();
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMRevision.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketPullRequestSCMRevision.java
@@ -13,7 +13,7 @@ public class BitbucketPullRequestSCMRevision extends ChangeRequestSCMRevision<Bi
 
     private final String latestCommit;
 
-    public BitbucketPullRequestSCMRevision(BitbucketPullRequestSCMHead head, SCMRevision target) {
+    private BitbucketPullRequestSCMRevision(BitbucketPullRequestSCMHead head, SCMRevision target) {
         super(head, target);
         this.latestCommit = requireNonNull(head, "head").getLatestCommit();
     }
@@ -32,6 +32,7 @@ public class BitbucketPullRequestSCMRevision extends ChangeRequestSCMRevision<Bi
                         String.valueOf(pullRequest.getId()),
                         pullRequest.getState(),
                         targetHead);
+
         return new BitbucketPullRequestSCMRevision(sourceHead, targetRevision);
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHead.java
@@ -1,0 +1,19 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import jenkins.scm.api.SCMHead;
+
+import static java.util.Objects.requireNonNull;
+
+public class BitbucketSCMHead extends SCMHead {
+
+    private final String latestCommit;
+
+    public BitbucketSCMHead(String name, String latestCommit) {
+        super(name);
+        this.latestCommit = requireNonNull(latestCommit, "latestCommit");
+    }
+
+    public String getLatestCommit() {
+        return latestCommit;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
@@ -1,0 +1,27 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import hudson.model.TaskListener;
+import jenkins.scm.api.*;
+
+import java.util.stream.Stream;
+
+/**
+ * Handles the discovery of different head types to be used by the
+ * {@link BitbucketSCMSource#retrieve(SCMSourceCriteria, SCMHeadObserver, SCMHeadEvent, TaskListener)} method as part
+ * or processing a {@link BitbucketSCMSourceRequest request}.
+ */
+public interface BitbucketSCMHeadDiscoveryHandler<H extends SCMHead, R extends SCMRevision> {
+
+    /**
+     * @return as stream of {@link SCMHead heads} to be used for processing the source request
+     */
+    Stream<H> discoverHeads();
+
+    /**
+     * Creates a {@link SCMRevision revision} for the specified head.
+     *
+     * @param head the head to create a revision for
+     * @return the revision for the specified head
+     */
+    R toRevision(H head);
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMHeadDiscoveryHandler.java
@@ -10,12 +10,12 @@ import java.util.stream.Stream;
  * {@link BitbucketSCMSource#retrieve(SCMSourceCriteria, SCMHeadObserver, SCMHeadEvent, TaskListener)} method as part
  * or processing a {@link BitbucketSCMSourceRequest request}.
  */
-public interface BitbucketSCMHeadDiscoveryHandler<H extends SCMHead, R extends SCMRevision> {
+public interface BitbucketSCMHeadDiscoveryHandler {
 
     /**
      * @return as stream of {@link SCMHead heads} to be used for processing the source request
      */
-    Stream<H> discoverHeads();
+    Stream<SCMHead> discoverHeads();
 
     /**
      * Creates a {@link SCMRevision revision} for the specified head.
@@ -23,5 +23,5 @@ public interface BitbucketSCMHeadDiscoveryHandler<H extends SCMHead, R extends S
      * @param head the head to create a revision for
      * @return the revision for the specified head
      */
-    R toRevision(H head);
+    SCMRevision toRevision(SCMHead head);
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
@@ -1,0 +1,44 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketFilePathClient;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMProbe;
+import jenkins.scm.api.SCMProbeStat;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class BitbucketSCMProbe extends SCMProbe {
+
+    private final BitbucketFilePathClient filePathClient;
+    private final SCMHead head;
+
+    public BitbucketSCMProbe(SCMHead head, BitbucketFilePathClient filePathClient) {
+        this.filePathClient = requireNonNull(filePathClient, "filePathClient");
+        this.head = requireNonNull(head, "head");
+    }
+
+    @Override
+    public String name() {
+        return head.getName();
+    }
+
+    @Override
+    public long lastModified() {
+        // This is supposed to indicate when the head was last modified (e.g. the most recent commit timestamp).
+        // However, we are not using it directly, so we're just using 0 for now.
+        return 0L;
+    }
+
+    @Override
+    public SCMProbeStat stat(String path) throws IOException {
+        requireNonNull(path, "path");
+
+        return SCMProbeStat.fromType(filePathClient.getFileType(path, head.getName()));
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMProbe.java
@@ -35,10 +35,18 @@ public class BitbucketSCMProbe extends SCMProbe {
     public SCMProbeStat stat(String path) throws IOException {
         requireNonNull(path, "path");
 
-        return SCMProbeStat.fromType(filePathClient.getFileType(path, head.getName()));
+        return SCMProbeStat.fromType(filePathClient.getFileType(path, getRef()));
     }
 
     @Override
     public void close() throws IOException {
+    }
+
+    private String getRef() {
+        if (head instanceof BitbucketPullRequestSCMHead) {
+            return ((BitbucketPullRequestSCMHead) head).getOriginName();
+        }
+
+        return head.getName();
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMRevision.java
@@ -1,0 +1,40 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMRevision;
+
+import static java.util.Objects.requireNonNull;
+
+public class BitbucketSCMRevision extends SCMRevision {
+
+    private final String latestCommit;
+
+    public BitbucketSCMRevision(@NonNull BitbucketSCMHead head) {
+        super(head);
+        this.latestCommit = requireNonNull(head, "head").getLatestCommit();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BitbucketSCMRevision) {
+            BitbucketSCMRevision that = (BitbucketSCMRevision) obj;
+            return getHead().equals(that.getHead()) && latestCommit.equals(that.latestCommit);
+        }
+
+        return false;
+    }
+
+    public String getLatestCommit() {
+        return latestCommit;
+    }
+
+    @Override
+    public int hashCode() {
+        return getHead().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return latestCommit;
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -8,6 +8,7 @@ import com.atlassian.bitbucket.jenkins.internal.credentials.CredentialUtils;
 import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketNamedLink;
 import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
+import com.atlassian.bitbucket.jenkins.internal.scm.trait.BitbucketSCMSourceTrait;
 import com.atlassian.bitbucket.jenkins.internal.status.BitbucketRepositoryMetadataAction;
 import com.atlassian.bitbucket.jenkins.internal.trigger.BitbucketWebhookMultibranchTrigger;
 import com.atlassian.bitbucket.jenkins.internal.trigger.RetryingWebhookHandler;
@@ -288,7 +289,12 @@ public class BitbucketSCMSource extends SCMSource {
                 return;
             }
 
-            doRetrieveLegacy(criteria, observer, event, listener);
+            if (getTraits().isEmpty() ||
+                    getTraits().stream().anyMatch(trait -> !(trait instanceof BitbucketSCMSourceTrait))) {
+                doRetrieveLegacy(criteria, observer, event, listener);
+            }
+
+            doRetrieve(criteria, observer, event, listener);
         }
     }
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSource.java
@@ -291,9 +291,7 @@ public class BitbucketSCMSource extends SCMSource {
                 return;
             }
 
-            // If none of the "old" traits have been enabled we can skip the old retrieve
-            if (getTraits().isEmpty() ||
-                    getTraits().stream().anyMatch(trait -> !(trait instanceof BitbucketSCMSourceTrait))) {
+            if (hasLegacyTraits()) {
                 doRetrieveLegacy(criteria, observer, event, listener);
             }
 
@@ -361,6 +359,16 @@ public class BitbucketSCMSource extends SCMSource {
                                   @CheckForNull SCMHeadEvent<?> event,
                                   TaskListener listener) throws IOException, InterruptedException {
         getFullyInitializedGitSCMSource().accessibleRetrieve(criteria, observer, event, listener);
+    }
+
+    private boolean hasLegacyTraits() {
+        return getTraits().stream().anyMatch(trait -> !(trait instanceof BitbucketSCMSourceTrait));
+    }
+
+    private List<SCMSourceTrait> getBitbucketSourceTraits() {
+        return getTraits().stream()
+                .filter(BitbucketSCMSourceTrait.class::isInstance)
+                .collect(Collectors.toList());
     }
 
     // Resolves the SCM repository, and the Git SCM. This involves a callout to Bitbucket so it must be done after the

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
@@ -1,0 +1,22 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.model.TaskListener;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.trait.SCMSourceContext;
+
+public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSourceContext, BitbucketSCMSourceRequest> {
+
+    public BitbucketSCMSourceContext(@Nullable SCMSourceCriteria criteria, SCMHeadObserver observer) {
+        super(criteria, observer);
+    }
+
+    @NonNull
+    @Override
+    public BitbucketSCMSourceRequest newRequest(SCMSource source, @Nullable TaskListener listener) {
+        return new BitbucketSCMSourceRequest(source, this, listener);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
@@ -14,10 +14,14 @@ import static java.util.Objects.requireNonNull;
 
 public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSourceContext, BitbucketSCMSourceRequest> {
 
-    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler<?, ?>> discoveryHandlers = new HashMap<>();
+    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> discoveryHandlers = new HashMap<>();
 
     public BitbucketSCMSourceContext(@Nullable SCMSourceCriteria criteria, SCMHeadObserver observer) {
         super(criteria, observer);
+    }
+
+    public Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> getDiscoveryHandlers() {
+        return discoveryHandlers;
     }
 
     @Override
@@ -26,7 +30,7 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     }
 
     public void withDiscoveryHandler(BitbucketDiscoverableHeadType discoverableHeadType,
-                                     BitbucketSCMHeadDiscoveryHandler<?, ?> discoveryHandler) {
+                                     BitbucketSCMHeadDiscoveryHandler discoveryHandler) {
         requireNonNull(discoverableHeadType, "discoverableHeadType");
         requireNonNull(discoveryHandler, "discoveryHandler");
 

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
@@ -1,6 +1,5 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.model.TaskListener;
 import jenkins.scm.api.SCMHeadObserver;
@@ -8,15 +7,29 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.trait.SCMSourceContext;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
 public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSourceContext, BitbucketSCMSourceRequest> {
+
+    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler<?, ?>> discoveryHandlers = new HashMap<>();
 
     public BitbucketSCMSourceContext(@Nullable SCMSourceCriteria criteria, SCMHeadObserver observer) {
         super(criteria, observer);
     }
 
-    @NonNull
     @Override
     public BitbucketSCMSourceRequest newRequest(SCMSource source, @Nullable TaskListener listener) {
         return new BitbucketSCMSourceRequest(source, this, listener);
+    }
+
+    public void withDiscoveryHandler(BitbucketDiscoverableHeadType discoverableHeadType,
+                                     BitbucketSCMHeadDiscoveryHandler<?, ?> discoveryHandler) {
+        requireNonNull(discoverableHeadType, "discoverableHeadType");
+        requireNonNull(discoveryHandler, "discoveryHandler");
+
+        discoveryHandlers.put(discoverableHeadType, discoveryHandler);
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceContext.java
@@ -1,5 +1,6 @@
 package com.atlassian.bitbucket.jenkins.internal.scm;
 
+import com.cloudbees.plugins.credentials.Credentials;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.model.TaskListener;
 import jenkins.scm.api.SCMHeadObserver;
@@ -9,19 +10,36 @@ import jenkins.scm.api.trait.SCMSourceContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSourceContext, BitbucketSCMSourceRequest> {
 
-    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> discoveryHandlers = new HashMap<>();
+    private final Credentials credentials;
+    private final BitbucketSCMRepository repository;
+    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> discoveryHandlers =
+            new HashMap<>();
 
-    public BitbucketSCMSourceContext(@Nullable SCMSourceCriteria criteria, SCMHeadObserver observer) {
+    public BitbucketSCMSourceContext(@Nullable SCMSourceCriteria criteria,
+                                     SCMHeadObserver observer,
+                                     @Nullable Credentials credentials,
+                                     BitbucketSCMRepository repository) {
         super(criteria, observer);
+        this.credentials = credentials;
+        this.repository = requireNonNull(repository, "repository");
     }
 
     public Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> getDiscoveryHandlers() {
         return discoveryHandlers;
+    }
+
+    public Optional<Credentials> getCredentials() {
+        return Optional.ofNullable(credentials);
+    }
+
+    public BitbucketSCMRepository getRepository() {
+        return repository;
     }
 
     @Override

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceRequest.java
@@ -1,0 +1,15 @@
+package com.atlassian.bitbucket.jenkins.internal.scm;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.model.TaskListener;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceRequest;
+
+public class BitbucketSCMSourceRequest extends SCMSourceRequest {
+
+    protected BitbucketSCMSourceRequest(SCMSource source,
+                                        BitbucketSCMSourceContext context,
+                                        @Nullable TaskListener listener) {
+        super(source, context, listener);
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketSCMSourceRequest.java
@@ -5,11 +5,22 @@ import hudson.model.TaskListener;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceRequest;
 
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
 public class BitbucketSCMSourceRequest extends SCMSourceRequest {
+
+    private final Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> discoveryHandlers;
 
     protected BitbucketSCMSourceRequest(SCMSource source,
                                         BitbucketSCMSourceContext context,
                                         @Nullable TaskListener listener) {
         super(source, context, listener);
+        this.discoveryHandlers = requireNonNull(context.getDiscoveryHandlers(), "discoveryHandlers");
+    }
+
+    public Map<BitbucketDiscoverableHeadType, BitbucketSCMHeadDiscoveryHandler> getDiscoveryHandlers() {
+        return discoveryHandlers;
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/BitbucketScmHelper.java
@@ -2,16 +2,15 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactory;
 import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketFilePathClient;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.BitbucketClientException;
 import com.atlassian.bitbucket.jenkins.internal.client.exception.NotFoundException;
 import com.atlassian.bitbucket.jenkins.internal.credentials.BitbucketCredentials;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketDefaultBranch;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketProject;
-import com.atlassian.bitbucket.jenkins.internal.model.BitbucketRepository;
-import com.atlassian.bitbucket.jenkins.internal.model.RepositoryState;
+import com.atlassian.bitbucket.jenkins.internal.model.*;
 
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getProjectByNameOrKey;
 import static com.atlassian.bitbucket.jenkins.internal.client.BitbucketSearchHelper.getRepositoryByNameOrSlug;
@@ -60,7 +59,7 @@ public class BitbucketScmHelper {
             return new BitbucketRepository(-1, repositoryName, null, new BitbucketProject(projectName, null, projectName), repositoryName, RepositoryState.AVAILABLE);
         }
     }
-    
+
     public Optional<BitbucketDefaultBranch> getDefaultBranch(String projectName, String repositoryName) {
         if (isBlank(projectName) || isBlank(repositoryName)) {
             LOGGER.info("Error creating the Bitbucket SCM: The projectName and repositoryName must not be blank");
@@ -84,7 +83,7 @@ public class BitbucketScmHelper {
                         "Error creating the Bitbucket SCM: Something went wrong when trying to contact Bitbucket Server: "
                                 + e.getMessage());
                 return Optional.empty();
-            }   
+            }
         } catch (NotFoundException e) {
             LOGGER.info("Error creating the Bitbucket SCM: Cannot find the project " + projectName);
             return Optional.empty();
@@ -95,5 +94,17 @@ public class BitbucketScmHelper {
                     e.getMessage());
             return Optional.empty();
         }
+    }
+
+    public Stream<BitbucketPullRequest> getOpenPullRequests(String projectKey, String repositorySlug) {
+        return clientFactory.getProjectClient(projectKey)
+                .getRepositoryClient(repositorySlug)
+                .getPullRequests(BitbucketPullRequestState.OPEN);
+    }
+
+    public BitbucketFilePathClient getFilePathClient(String projectKey, String repositorySlug) {
+        return clientFactory.getProjectClient(projectKey)
+                .getRepositoryClient(repositorySlug)
+                .getFilePathClient();
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/CustomGitSCMSource.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/CustomGitSCMSource.java
@@ -2,9 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.scm;
 
 import hudson.model.TaskListener;
 import jenkins.plugins.git.GitSCMSource;
-import jenkins.scm.api.SCMHeadEvent;
-import jenkins.scm.api.SCMHeadObserver;
-import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.*;
 
 import javax.annotation.CheckForNull;
 import java.io.IOException;
@@ -31,6 +29,11 @@ class CustomGitSCMSource extends GitSCMSource {
                                    @CheckForNull SCMHeadEvent<?> event,
                                    TaskListener listener) throws IOException, InterruptedException {
         super.retrieve(criteria, observer, event, listener);
+    }
+
+    public SCMRevision accessibleRetrieve(SCMHead head, TaskListener listener)
+            throws IOException, InterruptedException {
+        return super.retrieve(head, listener);
     }
 
     public BitbucketSCMRepository getRepository() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
@@ -13,7 +13,6 @@ import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMRevision;
-import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
@@ -123,18 +122,8 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
         }
 
         @Override
-        public Class<? extends SCMSourceContext> getContextClass() {
-            return BitbucketSCMSourceContext.class;
-        }
-
-        @Override
         public String getDisplayName() {
             return "Bitbucket Server: Discover pull requests";
-        }
-
-        @Override
-        public boolean isApplicableTo(@NonNull Class<? extends SCMSource> sourceClass) {
-            return BitbucketSCMSource.class.isAssignableFrom(sourceClass);
         }
     }
 }

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
@@ -1,7 +1,13 @@
 package com.atlassian.bitbucket.jenkins.internal.scm.trait;
 
+import com.atlassian.bitbucket.jenkins.internal.client.BitbucketClientFactoryProvider;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.config.BitbucketServerConfiguration;
+import com.atlassian.bitbucket.jenkins.internal.credentials.JenkinsToBitbucketCredentials;
 import com.atlassian.bitbucket.jenkins.internal.scm.*;
+import com.cloudbees.plugins.credentials.Credentials;
 import hudson.Extension;
+import jenkins.plugins.git.GitSCMBuilder;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.trait.SCMBuilder;
@@ -9,7 +15,13 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.Optional;
 import java.util.stream.Stream;
+
+import static com.atlassian.bitbucket.jenkins.internal.scm.BitbucketPullRequestSCMHead.PR_ID_PREFIX;
 
 public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait {
 
@@ -20,12 +32,29 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         if (context instanceof BitbucketSCMSourceContext) {
-            ((BitbucketSCMSourceContext) context).withDiscoveryHandler(BitbucketDiscoverableHeadType.PULL_REQUEST,
+            BitbucketSCMSourceContext bitbucketContext = (BitbucketSCMSourceContext) context;
+            BitbucketSCMRepository repository = bitbucketContext.getRepository();
+            bitbucketContext.withDiscoveryHandler(BitbucketDiscoverableHeadType.PULL_REQUEST,
                     new BitbucketSCMHeadDiscoveryHandler() {
 
                         @Override
                         public Stream<SCMHead> discoverHeads() {
-                            return Stream.empty();
+                            DescriptorImpl descriptor = (DescriptorImpl) getDescriptor();
+                            Optional<BitbucketServerConfiguration> mayBeServerConf =
+                                    descriptor.getConfiguration(bitbucketContext.getRepository().getServerId());
+                            if (!mayBeServerConf.isPresent()) {
+                                return Stream.empty();
+                            }
+
+                            BitbucketServerConfiguration serverConfiguration = mayBeServerConf.get();
+                            BitbucketScmHelper scmHelper =
+                                    descriptor.getBitbucketScmHelper(serverConfiguration.getBaseUrl(),
+                                            bitbucketContext.getCredentials().orElse(null));
+
+                            return scmHelper.getOpenPullRequests(repository.getProjectKey(),
+                                            repository.getRepositorySlug())
+                                    .map(BitbucketPullRequestSCMRevision::fromPullRequest)
+                                    .map(BitbucketPullRequestSCMRevision::getHead);
                         }
 
                         @Override
@@ -40,11 +69,32 @@ public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait 
 
     @Override
     protected void decorateBuilder(SCMBuilder<?, ?> builder) {
-        super.decorateBuilder(builder);
+        if (builder instanceof GitSCMBuilder) {
+            ((GitSCMBuilder<?>) builder)
+                    .withRefSpec("+refs/pull-requests/*/from:refs/remotes/@{remote}/"
+                            + PR_ID_PREFIX + "*");
+        }
     }
 
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        @Inject
+        private BitbucketClientFactoryProvider bitbucketClientFactoryProvider;
+        @Inject
+        private BitbucketPluginConfiguration bitbucketPluginConfiguration;
+        @Inject
+        private JenkinsToBitbucketCredentials jenkinsToBitbucketCredentials;
+
+        BitbucketScmHelper getBitbucketScmHelper(String bitbucketUrl, @CheckForNull Credentials httpCredentials) {
+            return new BitbucketScmHelper(bitbucketUrl,
+                    bitbucketClientFactoryProvider,
+                    jenkinsToBitbucketCredentials.toBitbucketCredentials(httpCredentials));
+        }
+
+        Optional<BitbucketServerConfiguration> getConfiguration(@Nullable String serverId) {
+            return bitbucketPluginConfiguration.getServerById(serverId);
+        }
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
@@ -6,13 +6,12 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
-import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.stream.Stream;
 
-public class BitbucketPullRequestDiscoveryTrait extends SCMSourceTrait {
+public class BitbucketPullRequestDiscoveryTrait extends BitbucketSCMSourceTrait {
 
     @DataBoundConstructor
     public BitbucketPullRequestDiscoveryTrait() {

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
@@ -1,0 +1,53 @@
+package com.atlassian.bitbucket.jenkins.internal.scm.trait;
+
+import com.atlassian.bitbucket.jenkins.internal.scm.*;
+import hudson.Extension;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.stream.Stream;
+
+public class BitbucketPullRequestDiscoveryTrait extends SCMSourceTrait {
+
+    @DataBoundConstructor
+    public BitbucketPullRequestDiscoveryTrait() {
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof BitbucketSCMSourceContext) {
+            ((BitbucketSCMSourceContext) context).withDiscoveryHandler(BitbucketDiscoverableHeadType.PULL_REQUEST,
+                    new BitbucketSCMHeadDiscoveryHandler<BitbucketPullRequestSCMHead,
+                            BitbucketPullRequestSCMRevision>() {
+
+                        @Override
+                        public Stream<BitbucketPullRequestSCMHead> discoverHeads() {
+                            return Stream.empty();
+                        }
+
+                        @Override
+                        public BitbucketPullRequestSCMRevision toRevision(BitbucketPullRequestSCMHead head) {
+                            return BitbucketPullRequestSCMRevision.fromPullRequestHead(head);
+                        }
+                    }
+            );
+        }
+    }
+
+    @Override
+    protected void decorateBuilder(SCMBuilder<?, ?> builder) {
+        super.decorateBuilder(builder);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Bitbucket Server: Discover pull requests";
+        }
+    }
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketPullRequestDiscoveryTrait.java
@@ -2,6 +2,8 @@ package com.atlassian.bitbucket.jenkins.internal.scm.trait;
 
 import com.atlassian.bitbucket.jenkins.internal.scm.*;
 import hudson.Extension;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
@@ -20,17 +22,17 @@ public class BitbucketPullRequestDiscoveryTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         if (context instanceof BitbucketSCMSourceContext) {
             ((BitbucketSCMSourceContext) context).withDiscoveryHandler(BitbucketDiscoverableHeadType.PULL_REQUEST,
-                    new BitbucketSCMHeadDiscoveryHandler<BitbucketPullRequestSCMHead,
-                            BitbucketPullRequestSCMRevision>() {
+                    new BitbucketSCMHeadDiscoveryHandler() {
 
                         @Override
-                        public Stream<BitbucketPullRequestSCMHead> discoverHeads() {
+                        public Stream<SCMHead> discoverHeads() {
                             return Stream.empty();
                         }
 
                         @Override
-                        public BitbucketPullRequestSCMRevision toRevision(BitbucketPullRequestSCMHead head) {
-                            return BitbucketPullRequestSCMRevision.fromPullRequestHead(head);
+                        public SCMRevision toRevision(SCMHead head) {
+                            return BitbucketPullRequestSCMRevision
+                                    .fromPullRequestHead((BitbucketPullRequestSCMHead) head);
                         }
                     }
             );

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketSCMSourceTrait.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/BitbucketSCMSourceTrait.java
@@ -1,0 +1,9 @@
+package com.atlassian.bitbucket.jenkins.internal.scm.trait;
+
+import jenkins.scm.api.trait.SCMSourceTrait;
+
+/**
+ * Used as a marker for new Bitbucket implementations of SCMSourceTrait.
+ */
+public abstract class BitbucketSCMSourceTrait extends SCMSourceTrait {
+}

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/package-info.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/scm/trait/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Add package level annotations to indicate everything is non-null by default.
+ */
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.atlassian.bitbucket.jenkins.internal.scm.trait;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
+++ b/src/main/java/com/atlassian/bitbucket/jenkins/internal/trigger/BitbucketWebhookConsumer.java
@@ -2,9 +2,7 @@ package com.atlassian.bitbucket.jenkins.internal.trigger;
 
 import com.atlassian.bitbucket.jenkins.internal.config.BitbucketPluginConfiguration;
 import com.atlassian.bitbucket.jenkins.internal.model.*;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCM;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMRepository;
-import com.atlassian.bitbucket.jenkins.internal.scm.BitbucketSCMSource;
+import com.atlassian.bitbucket.jenkins.internal.scm.*;
 import com.atlassian.bitbucket.jenkins.internal.trigger.events.*;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.git.GitSCM;
@@ -73,8 +71,8 @@ public class BitbucketWebhookConsumer {
                 BitbucketSCMHeadEvent.fireNow(new BitbucketSCMHeadEvent(SCMEvent.Type.UPDATED, event,
                         eligibleUpdatedRefs, event.getRepository().getSlug()));
             }
-        } 
-        
+        }
+
         Set<BitbucketRefChange> deletedRefs = new HashSet<>(event.getChanges());
         deletedRefs.removeAll(eligibleUpdatedRefs);
         if (!deletedRefs.isEmpty()) {
@@ -87,17 +85,17 @@ public class BitbucketWebhookConsumer {
         LOGGER.fine("Received pull request event");
         if (event instanceof PullRequestOpenedWebhookEvent || event instanceof PullRequestFromRefUpdatedWebhookEvent) {
             RefChangedDetails refChangedDetails = new RefChangedDetails(event);
-            
+
             try (ACLContext ignored = ACL.as(ACL.SYSTEM)) {
                 BitbucketWebhookTriggerRequest.Builder requestBuilder = BitbucketWebhookTriggerRequest.builder();
                 event.getActor().ifPresent(requestBuilder::actor);
-                
+
                 processJobs(event, refChangedDetails, requestBuilder);
                 BitbucketSCMHeadPullRequestEvent.fireNow(new BitbucketSCMHeadPullRequestEvent(getSCMEventType(event),
                         event, event.getPullRequest().getToRef().getRepository().getSlug()));
             }
         } else if (event instanceof PullRequestClosedWebhookEvent) {
-            BitbucketSCMHeadPullRequestEvent.fireNow(new BitbucketSCMHeadPullRequestEvent(SCMEvent.Type.REMOVED, event, 
+            BitbucketSCMHeadPullRequestEvent.fireNow(new BitbucketSCMHeadPullRequestEvent(SCMEvent.Type.REMOVED, event,
                     event.getPullRequest().getFromRef().getRepository().getSlug()));
         }
     }
@@ -108,7 +106,7 @@ public class BitbucketWebhookConsumer {
                 .filter(refChange -> refChange.getType() != BitbucketRefChangeType.DELETE)
                 .collect(Collectors.toSet());
     }
-    
+
     private static SCMEvent.Type getSCMEventType(PullRequestWebhookEvent event) {
         if (event instanceof PullRequestOpenedWebhookEvent) {
             return SCMEvent.Type.CREATED;
@@ -249,9 +247,10 @@ public class BitbucketWebhookConsumer {
                 return emptyMap();
             }
 
-            BitbucketPullRequestRef fromRef = getPayload().getPullRequest().getFromRef();
-            return Collections.singletonMap(new GitBranchSCMHead(fromRef.getDisplayId()),
-                    new GitBranchSCMRevision(new GitBranchSCMHead(fromRef.getDisplayId()), fromRef.getLatestCommit()));
+            BitbucketPullRequestSCMRevision prRevision =
+                    BitbucketPullRequestSCMRevision.fromPullRequest(getPayload().getPullRequest());
+
+            return Collections.singletonMap(prRevision.getHead(), prRevision);
         }
 
         @Override
@@ -266,7 +265,7 @@ public class BitbucketWebhookConsumer {
     }
 
     static class BitbucketSCMHeadEvent extends SCMHeadEvent<RefsChangedWebhookEvent> {
-        
+
         private Collection<BitbucketRefChange> effectiveRefs;
 
         public BitbucketSCMHeadEvent(Type type, RefsChangedWebhookEvent payload, Collection<BitbucketRefChange> effectiveRefs, String origin) {
@@ -289,7 +288,7 @@ public class BitbucketWebhookConsumer {
                 return emptyMap();
             }
             return effectiveRefs.stream()
-                    .collect(Collectors.toMap(change -> new GitBranchSCMHead(change.getRef().getDisplayId()), 
+                    .collect(Collectors.toMap(change -> new GitBranchSCMHead(change.getRef().getDisplayId()),
                             change -> new GitBranchSCMRevision(new GitBranchSCMHead(change.getRef().getDisplayId()), change.getToHash())));
         }
 


### PR DESCRIPTION
This is a POC for using a discovery trait to add PR support instead of a filter branch. This approach seems to give us more flexibility with decoupling from the `GitSCMSource#retrieve` method and is a viable option for milestone 1.